### PR TITLE
lightbits/build: add checkout dependency for cleanup target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install_dir:
 checkin:
 	$(Q)component-tool checkin -v --repo=amzn-drivers --type=$(BUILD_TYPE) aws_modules
 
-clean:
+clean: checkout_deps
 	$(Q)$(MAKE) -C kernel/linux/ena clean
 
 .PHONY: checkout_deps clean install_dir checkin


### PR DESCRIPTION
Dependency checkout is needed for clean target as our rootfs performs
clean before build and if kernel headers are not present clean target fails